### PR TITLE
Update state detection logic

### DIFF
--- a/AmongUsCapture/GameMemReader.cs
+++ b/AmongUsCapture/GameMemReader.cs
@@ -34,6 +34,7 @@ namespace AmongUsCapture
 
         private IntPtr GameAssemblyPtr = IntPtr.Zero;
         private GameState oldState = GameState.LOBBY;
+        private bool exileCausesEnd = false;
 
         public void RunLoop()
         {
@@ -67,7 +68,7 @@ namespace AmongUsCapture
                             if (!foundModule)
                             {
                                 Console.WriteLine("Still looking for modules...");
-                                Task.Delay(500); // delay and try again
+                                Thread.Sleep(500); // delay and try again
                             } else
                             {
                                 break; // we have found all modules
@@ -86,8 +87,14 @@ namespace AmongUsCapture
                 if (gameState == 0)
                 {
                     state = GameState.MENU;
+                    exileCausesEnd = false;
                 }
                 else if (gameState == 1 || gameState == 3)
+                {
+                    state = GameState.LOBBY;
+                    exileCausesEnd = false;
+                }
+                else if (exileCausesEnd)
                 {
                     state = GameState.LOBBY;
                 }
@@ -97,6 +104,37 @@ namespace AmongUsCapture
                 } else
                 {
                     state = GameState.TASKS;
+                }
+
+                IntPtr allPlayersPtr = ProcessMemory.Read<IntPtr>(GameAssemblyPtr, 0xDA5A60, 0x5C, 0, 0x24);
+                IntPtr allPlayers = ProcessMemory.Read<IntPtr>(allPlayersPtr, 0x08);
+                int playerCount = ProcessMemory.Read<int>(allPlayersPtr, 0x0C);
+
+                IntPtr playerAddrPtr = allPlayers + 0x10;
+
+                // check if exile causes end
+                if (oldState == GameState.DISCUSSION && state == GameState.TASKS)
+                {
+                    byte exiledPlayerId = ProcessMemory.Read<byte>(GameAssemblyPtr, 0xDA58D0, 0x5C, 0, 0x94, 0x08);
+                    int impostorCount = 0, innocentCount = 0;
+
+                    for (int i = 0; i < playerCount; i++)
+                    {
+                        IntPtr playerAddr = ProcessMemory.Read<IntPtr>(playerAddrPtr);
+                        PlayerInfo pi = ProcessMemory.Read<PlayerInfo>(playerAddr);
+
+                        // skip invalid, dead and exiled players
+                        if (pi.PlayerName == 0 || pi.PlayerId == exiledPlayerId || pi.IsDead == 1) { continue; }
+
+                        if (pi.IsImpostor == 1) { impostorCount++; }
+                        else { innocentCount++; }
+                    }
+
+                    if (impostorCount == 0 || impostorCount >= innocentCount)
+                    {
+                        exileCausesEnd = true;
+                        state = GameState.LOBBY;
+                    }
                 }
 
                 if (this.shouldTransmitState)
@@ -117,13 +155,6 @@ namespace AmongUsCapture
                 }
 
                 oldState = state;
-
-
-                IntPtr allPlayersPtr = ProcessMemory.Read<IntPtr>(GameAssemblyPtr, 0xDA5A60, 0x5C, 0, 0x24);
-                IntPtr allPlayers = ProcessMemory.Read<IntPtr>(allPlayersPtr, 0x08);
-                int playerCount = ProcessMemory.Read<int>(allPlayersPtr, 0x0C);
-
-                IntPtr playerAddrPtr = allPlayers + 0x10;
 
                 newPlayerInfos.Clear();
 

--- a/AmongUsCapture/GameMemReader.cs
+++ b/AmongUsCapture/GameMemReader.cs
@@ -33,7 +33,6 @@ namespace AmongUsCapture
         public Dictionary<string, PlayerInfo> newPlayerInfos = new Dictionary<string, PlayerInfo>(10); // container for new player infos. Also has capacity 10 already assigned so no internal resizing of the data structure is needed
 
         private IntPtr GameAssemblyPtr = IntPtr.Zero;
-        private IntPtr UnityPlayerPtr = IntPtr.Zero;
         private GameState oldState = GameState.LOBBY;
 
         public void RunLoop()
@@ -51,28 +50,21 @@ namespace AmongUsCapture
                     {
                         Console.WriteLine("Connected to Among Us process ({0})", ProcessMemory.process.Id);
 
-                        int modulesLeft;
+                        bool foundModule = false;
 
                         while(true)
                         {
-                            modulesLeft = 2;
                             foreach (ProcessMemory.Module module in ProcessMemory.modules)
                             {
-                                if (modulesLeft == 0)
-                                    break;
-                                else if (module.Name.Equals("GameAssembly.dll", StringComparison.OrdinalIgnoreCase))
+                                if (module.Name.Equals("GameAssembly.dll", StringComparison.OrdinalIgnoreCase))
                                 {
                                     GameAssemblyPtr = module.BaseAddress;
-                                    modulesLeft--;
-                                }
-                                else if (module.Name.Equals("UnityPlayer.dll", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    UnityPlayerPtr = module.BaseAddress;
-                                    modulesLeft--;
+                                    foundModule = true;
+                                    break;
                                 }
                             }
 
-                            if (UnityPlayerPtr == IntPtr.Zero || GameAssemblyPtr == IntPtr.Zero) // either one or both hasn't been found yet
+                            if (!foundModule)
                             {
                                 Console.WriteLine("Still looking for modules...");
                                 Task.Delay(500); // delay and try again
@@ -83,7 +75,7 @@ namespace AmongUsCapture
                         }
                         
 
-                        Console.WriteLine($"({GameAssemblyPtr}) ({UnityPlayerPtr})");
+                        Console.WriteLine($"({GameAssemblyPtr})");
                     }
                 }
 


### PR DESCRIPTION
Should fix the problem that causes mute because discussion ended and unmute because game ended right after, very likely hitting api limit.