### PR TITLE
Remove the callbacks when a client disconnects

### DIFF
--- a/AmongUsCapture/ClientSocket.cs
+++ b/AmongUsCapture/ClientSocket.cs
@@ -23,7 +23,12 @@ namespace AmongUsCapture
                 GameMemReader.getInstance().GameStateChanged += GameStateChangedHandler;
                 GameMemReader.getInstance().PlayerChanged += PlayerChangedHandler;
             };
-
+            
+            socket.OnDisconnected += (sender, e) =>
+            {
+                GameMemReader.getInstance().GameStateChanged -= GameStateChangedHandler;
+                GameMemReader.getInstance().PlayerChanged -= PlayerChangedHandler;
+            };
 
             socket.ConnectAsync();
         }


### PR DESCRIPTION
So the callbacks get added on connected, and since SocketIO will automatically reconnect, you'll add another identical callback if the client disconnects and reconnects for whatever reason. This can cause a ton of additional traffic if the connection is flapping or someone leaves their client up for a long time while the backend goes up and down