### PR TITLE
Rework of ProcessMemory for better cross-platform support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,29 @@ UpgradeLog*.htm
 App_Data/*.mdf
 App_Data/*.ldf
 
+# Common IntelliJ Platform excludes
+
+# User specific
+**/.idea/**/workspace.xml
+**/.idea/**/tasks.xml
+**/.idea/shelf/*
+**/.idea/dictionaries
+**/.idea/httpRequests/
+
+# Sensitive or high-churn files
+**/.idea/**/dataSources/
+**/.idea/**/dataSources.ids
+**/.idea/**/dataSources.xml
+**/.idea/**/dataSources.local.xml
+**/.idea/**/sqlDataSources.xml
+**/.idea/**/dynamic.xml
+
+# Rider
+# Rider auto-generates .iml files, and contentModel.xml
+**/.idea/**/*.iml
+**/.idea/**/contentModel.xml
+**/.idea/**/modules.xml
+
 # =========================
 # Windows detritus
 # =========================

--- a/AmongUsCapture/Memory/ProcessMemoryBase.cs
+++ b/AmongUsCapture/Memory/ProcessMemoryBase.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace AmongUsCapture
+{
+    public abstract class ProcessMemoryBase
+    {
+        protected bool is64Bit;
+        public Process process;
+        public List<Module> modules;
+        public bool IsHooked { get; protected set; }
+        public abstract bool HookProcess(string name);
+        public abstract void LoadModules();
+        public abstract T Read<T>(IntPtr address, params int[] offsets) where T : unmanaged;
+        public abstract T ReadWithDefault<T>(IntPtr address, T defaultparam, params int[] offsets) where T : unmanaged;
+
+        public abstract string ReadString(IntPtr address);
+        public abstract IntPtr[] ReadArray(IntPtr address, int size);
+
+        public class Module
+        {
+            public IntPtr BaseAddress { get; set; }
+            public IntPtr EntryPointAddress { get; set; }
+            public string FileName { get; set; }
+            public uint MemorySize { get; set; }
+            public string Name { get; set; }
+            public FileVersionInfo FileVersionInfo { get { return FileVersionInfo.GetVersionInfo(FileName); } }
+            public override string ToString()
+            {
+                return Name ?? base.ToString();
+            }
+        }
+        [StructLayout(LayoutKind.Sequential)]
+        protected struct ModuleInfo
+        {
+            public IntPtr BaseAddress;
+            public uint ModuleSize;
+            public IntPtr EntryPoint;
+        }
+    }
+
+
+}

--- a/AmongUsCapture/Memory/ProcessMemoryWindows.cs
+++ b/AmongUsCapture/Memory/ProcessMemoryWindows.cs
@@ -118,7 +118,7 @@ namespace AmongUsCapture
             if (process == null || address == IntPtr.Zero)
                 return buffer;
 
-            WinAPI.ReadProcessMemoryBase(process.Handle, address, buffer, numBytes, out int bytesRead);
+            WinAPI.ReadProcessMemory(process.Handle, address, buffer, numBytes, out int bytesRead);
             return buffer;
         }
         private int OffsetAddress(ref IntPtr address, params int[] offsets)
@@ -126,7 +126,7 @@ namespace AmongUsCapture
             byte[] buffer = new byte[is64Bit ? 8 : 4];
             for (int i = 0; i < offsets.Length - 1; i++)
             {
-                WinAPI.ReadProcessMemoryBase(process.Handle, address + offsets[i], buffer, buffer.Length, out int bytesRead);
+                WinAPI.ReadProcessMemory(process.Handle, address + offsets[i], buffer, buffer.Length, out int bytesRead);
                 if (is64Bit)
                     address = (IntPtr)BitConverter.ToUInt64(buffer, 0);
                 else
@@ -139,7 +139,7 @@ namespace AmongUsCapture
         private static class WinAPI
         {
             [DllImport("kernel32.dll", SetLastError = true)]
-            public static extern bool ReadProcessMemoryBase(IntPtr hProcess, IntPtr lpBaseAddress, [Out] byte[] lpBuffer, int dwSize, out int lpNumberOfBytesRead);
+            public static extern bool ReadProcessMemory(IntPtr hProcess, IntPtr lpBaseAddress, [Out] byte[] lpBuffer, int dwSize, out int lpNumberOfBytesRead);
             [DllImport("kernel32.dll", SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
             public static extern bool IsWow64Process(IntPtr hProcess, [MarshalAs(UnmanagedType.Bool)] out bool wow64Process);

--- a/AmongUsCapture/Memory/ProcessMemoryWindows.cs
+++ b/AmongUsCapture/Memory/ProcessMemoryWindows.cs
@@ -6,13 +6,9 @@ using System.Text;
 
 namespace AmongUsCapture
 {
-    public static class ProcessMemory
+    public class ProcessMemoryWindows : ProcessMemoryBase
     {
-        private static bool is64Bit;
-        public static Process process;
-        public static List<Module> modules;
-        public static bool IsHooked { get; private set; } = false;
-        public static bool HookProcess(string name)
+        public override bool HookProcess(string name)
         {
             IsHooked = process != null && !process.HasExited;
             if (!IsHooked)
@@ -36,7 +32,7 @@ namespace AmongUsCapture
             return IsHooked;
         }
 
-        public static void LoadModules()
+        public override void LoadModules()
         {
             modules = new List<Module>();
             IntPtr[] buffer = new IntPtr[1024];
@@ -70,12 +66,12 @@ namespace AmongUsCapture
             }
         }
 
-        public static T Read<T>(IntPtr address, params int[] offsets) where T : unmanaged
+        public override T Read<T>(IntPtr address, params int[] offsets)
         {
             return ReadWithDefault<T>(address, default, offsets);
         }
 
-        public static T ReadWithDefault<T>(IntPtr address, T defaultParam, params int[] offsets) where T : unmanaged
+        public override T ReadWithDefault<T>(IntPtr address, T defaultParam, params int[] offsets)
         {
             if (process == null || address == IntPtr.Zero)
                 return defaultParam;
@@ -96,7 +92,7 @@ namespace AmongUsCapture
             }
         }
 
-        public static string ReadString(IntPtr address)
+        public override string ReadString(IntPtr address)
         {
             if (process == null || address == IntPtr.Zero)
                 return default;
@@ -105,7 +101,7 @@ namespace AmongUsCapture
             return System.Text.Encoding.Unicode.GetString(rawString);
         }
 
-        public static IntPtr[] ReadArray(IntPtr address, int size)
+        public override IntPtr[] ReadArray(IntPtr address, int size)
         {
             byte[] bytes = Read(address, size * 4);
             IntPtr[] ints = new IntPtr[size];
@@ -116,21 +112,21 @@ namespace AmongUsCapture
             return ints;
         }
 
-        private static byte[] Read(IntPtr address, int numBytes)
+        private byte[] Read(IntPtr address, int numBytes)
         {
             byte[] buffer = new byte[numBytes];
             if (process == null || address == IntPtr.Zero)
                 return buffer;
 
-            WinAPI.ReadProcessMemory(process.Handle, address, buffer, numBytes, out int bytesRead);
+            WinAPI.ReadProcessMemoryBase(process.Handle, address, buffer, numBytes, out int bytesRead);
             return buffer;
         }
-        private static int OffsetAddress(ref IntPtr address, params int[] offsets)
+        private int OffsetAddress(ref IntPtr address, params int[] offsets)
         {
             byte[] buffer = new byte[is64Bit ? 8 : 4];
             for (int i = 0; i < offsets.Length - 1; i++)
             {
-                WinAPI.ReadProcessMemory(process.Handle, address + offsets[i], buffer, buffer.Length, out int bytesRead);
+                WinAPI.ReadProcessMemoryBase(process.Handle, address + offsets[i], buffer, buffer.Length, out int bytesRead);
                 if (is64Bit)
                     address = (IntPtr)BitConverter.ToUInt64(buffer, 0);
                 else
@@ -143,7 +139,7 @@ namespace AmongUsCapture
         private static class WinAPI
         {
             [DllImport("kernel32.dll", SetLastError = true)]
-            public static extern bool ReadProcessMemory(IntPtr hProcess, IntPtr lpBaseAddress, [Out] byte[] lpBuffer, int dwSize, out int lpNumberOfBytesRead);
+            public static extern bool ReadProcessMemoryBase(IntPtr hProcess, IntPtr lpBaseAddress, [Out] byte[] lpBuffer, int dwSize, out int lpNumberOfBytesRead);
             [DllImport("kernel32.dll", SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
             public static extern bool IsWow64Process(IntPtr hProcess, [MarshalAs(UnmanagedType.Bool)] out bool wow64Process);
@@ -157,26 +153,6 @@ namespace AmongUsCapture
             [DllImport("psapi.dll", SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
             public static extern bool GetModuleInformation(IntPtr hProcess, IntPtr hModule, out ModuleInfo lpmodinfo, uint cb);
-        }
-        public class Module
-        {
-            public IntPtr BaseAddress { get; set; }
-            public IntPtr EntryPointAddress { get; set; }
-            public string FileName { get; set; }
-            public uint MemorySize { get; set; }
-            public string Name { get; set; }
-            public FileVersionInfo FileVersionInfo { get { return FileVersionInfo.GetVersionInfo(FileName); } }
-            public override string ToString()
-            {
-                return Name ?? base.ToString();
-            }
-        }
-        [StructLayout(LayoutKind.Sequential)]
-        private struct ModuleInfo
-        {
-            public IntPtr BaseAddress;
-            public uint ModuleSize;
-            public IntPtr EntryPoint;
         }
     }
 }

--- a/AmongUsCapture/PlayerInfo.cs
+++ b/AmongUsCapture/PlayerInfo.cs
@@ -25,7 +25,7 @@ namespace AmongUsCapture
 
         public string GetPlayerName()
         {
-            return ProcessMemory.ReadString((IntPtr)this.PlayerName);
+            return GameMemReader.getInstance().GetStringFromMemory((IntPtr)this.PlayerName);
         }
 
         public PlayerColor GetPlayerColor()


### PR DESCRIPTION
While testing amonguscapture-gtk, I found that the current ProcessMemory class doesn't provide a particularly good framework for cross platform support. This update reworks the ProcessMemory class into a more modular design and further organizes all of the the memory-related classes into their own directory.

To do so, I did the following:

ProcessMemory has been split from a single static class into an abstract class (ProcessMemoryBase), which platform-specific ProcessMemory implementations derive from.

ProcessMemoryBase still supplies the same common interface from the original ProcessMemory, which allows every implementation of ProcessMemory inheriting from it to supply the same functionality. All new implementations will need to do is inherit ProcessMemoryBase, override all necessary methods, and initialize itself in GameMemReader.

The naming convention for ProcessMemory children classes is "ProcessMemoryPlatform", such as ProcessMemoryWindows, or ProcessMemoryLinux.

Changes to GameMemReader were necessary, but required no fundamental changes to the core processing loop. ProcessMemory is now a member of GameMemReader, which now initializes the correct instance during initialization. New ProcessMemoryPlatform instances should be initialized in the constructor, and if a platform is not supported, a 'NotImplementedException' is currently thrown.

In the event that a class outside GameMemReader needs to access a public method of ProcessMemoryBase, public methods for certain calls (currently only GetStringFromMemory()) are provided. 

This is currently viable since the only PC version of Among Us available is the Windows release, which runs through Linux (and potentially MacOS and other .NET supported platforms) through Wine (https://www.protondb.com/app/945360). As dotnet is flaky under Wine, this allows for native implementations of the ProcessMemory code to operate and let people playing on alternate OS to play with and attach to the amongusdiscord bot.

If InnerSloth ever releases native clients for other platforms, it is likely possible that this will have to be revisited but since we only currently have a Windows client, this is not an issue.