### PR TITLE
Connect Code Input Fix (+ minor UI behaviour changes)

### DIFF
--- a/AmongUsCapture/UserForm.Designer.cs
+++ b/AmongUsCapture/UserForm.Designer.cs
@@ -256,7 +256,7 @@ namespace AmongUsCapture
             this.ConnectCodeBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
             this.ConnectCodeBox.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
             this.ConnectCodeBox.Location = new System.Drawing.Point(6, 6);
-            this.ConnectCodeBox.Mask = ">AAAAAA";
+            this.ConnectCodeBox.Mask = ">AAAAAAAA";
             this.ConnectCodeBox.Name = "ConnectCodeBox";
             this.ConnectCodeBox.Size = new System.Drawing.Size(115, 22);
             this.ConnectCodeBox.TabIndex = 0;

--- a/AmongUsCapture/UserForm.Designer.cs
+++ b/AmongUsCapture/UserForm.Designer.cs
@@ -272,6 +272,7 @@ namespace AmongUsCapture
             this.ConnectButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.ConnectButton.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(255)))));
             this.ConnectButton.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ConnectButton.Enabled = false;
             this.ConnectButton.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption;
             this.ConnectButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.ConnectButton.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));

--- a/AmongUsCapture/UserForm.cs
+++ b/AmongUsCapture/UserForm.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
@@ -259,7 +259,7 @@ namespace AmongUsCapture
 
         private void ConnectCodeBox_TextChanged(object sender, EventArgs e)
         {
-            ConnectButton.Enabled = (ConnectCodeBox.Enabled && ConnectCodeBox.Text.Length == 6 && !ConnectCodeBox.Text.Contains(" "));
+            ConnectButton.Enabled = (ConnectCodeBox.Enabled && ConnectCodeBox.Text.Length == 8 && !ConnectCodeBox.Text.Contains(" "));
         }
 
         private void ConsoleTextBox_TextChanged(object sender, EventArgs e)

--- a/AmongUsCapture/UserForm.cs
+++ b/AmongUsCapture/UserForm.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
@@ -211,9 +211,10 @@ namespace AmongUsCapture
         private void ConnectButton_Click(object sender, EventArgs e)
         {
 
-            ConnectCodeBox.Enabled = false;
+            /*ConnectCodeBox.Enabled = false;
             ConnectButton.Enabled = false;
-            URLTextBox.Enabled = false;
+            URLTextBox.Enabled = false;*/
+            ConnectCodeBox.Clear();
 
             var url = "http://localhost:8123";
             if (URLTextBox.Text != "")


### PR DESCRIPTION
- Change Connect Code input mask to accept 8 letter connect codes
- Disable Connect-Button when starting the program
- Do not disable input boxes when clicking Connect; Clear Connect Code input instead