### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "03:42"
+  open-pull-requests-limit: 10
+- package-ecosystem: nuget
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "03:42"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
successor of #72 
This PR adds [dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/) to the repo