### PR TITLE
Fix hint path for Win32.Registry include

### DIFF
--- a/AUCapture-Console/AUCapture-Console.csproj
+++ b/AUCapture-Console/AUCapture-Console.csproj
@@ -14,7 +14,7 @@
     <DebugType>none</DebugType>
   </PropertyGroup>
   <ItemGroup>
-  <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="SharedMemory" Version="2.2.3" />
   </ItemGroup>
 

--- a/AUCapture-Console/AUCapture-Console.csproj
+++ b/AUCapture-Console/AUCapture-Console.csproj
@@ -14,17 +14,12 @@
     <DebugType>none</DebugType>
   </PropertyGroup>
   <ItemGroup>
+  <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="SharedMemory" Version="2.2.3" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\AmongUsCapture\AmongUsCapture.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="Microsoft.Win32.Registry">
-      <HintPath>..\..\..\..\..\..\Program Files\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\3.1.0\ref\netcoreapp3.1\Microsoft.Win32.Registry.dll</HintPath>
-    </Reference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Because the hint path used relative pathing to find the DLL, if you have
the git repo on a different drive than your dotnet install the build
fails. This change makes the path absolute and uses the SystemDrive env
variable to ensure that it is not hard coded to C: